### PR TITLE
Update spline approximation precision in ImportDxf.cs for headless operation

### DIFF
--- a/CADability/ImportDxf.cs
+++ b/CADability/ImportDxf.cs
@@ -530,7 +530,7 @@ namespace CADability.DXF
 
                         ICurve curve = (ICurve)bsp;
                         //Use approximate to get the count of lines that will be needed to convert the spline into a Polyline2D
-                        double maxError = project.Frame.GetDoubleSetting("Approximate.Precision", 0.01);
+                        double maxError = Settings.GlobalSettings.GetDoubleValue("Approximate.Precision", 0.01);
                         ICurve approxCurve = curve.Approximate(true, maxError);
 
                         int usedCurves = 0;

--- a/CADability/Settings.cs
+++ b/CADability/Settings.cs
@@ -1021,6 +1021,10 @@ namespace CADability
                         {
                             ((IntegerProperty)(entries[Name])).SetInt((int)NewValue);
                         }
+                        else if (entries[Name].GetType() == typeof(DoubleProperty) && NewValue is double)
+                        {
+                            ((DoubleProperty)(entries[Name])).SetDouble((double)NewValue);
+                        }
                         else if (entries[Name].GetType() == typeof(ColorSetting))
                         {
                             ((ColorSetting)(entries[Name])).Color = (Color)NewValue;


### PR DESCRIPTION
In implementing this fix, it was found that the SetValue() method was lacking some handlers for certain settings types. Added a statement to set value for settings of type DoubleProperty. There may be more cases that need to be addressed in this method.

This setting can now be control by the user via:

```C#
Settings.GlobalSettings.SetValue("Approximate.Precision", 0.01);
```

Closes #187 