### PR TITLE
Compiler warning cleanup

### DIFF
--- a/CADability/BSpline.cs
+++ b/CADability/BSpline.cs
@@ -75,7 +75,6 @@ namespace CADability.GeoObject
         private GeoPoint[] interpol; // Interpolation mit einer gewissen Genauigkeit
         private GeoVector[] interdir; // Interpolation mit einer gewissen Genauigkeit
         private double[] interparam; // die Parameter zur Interpolation
-        private double maxInterpolError; // der größte Fehler bei der Interpolation
         private BoundingCube extent;
         private TetraederHull tetraederHull;
         private GeoPoint[] approximation; // Interpolation mit der Genauigkeit der Auflösung
@@ -517,7 +516,6 @@ namespace CADability.GeoObject
                 interdir = null;
                 interparam = null;
                 approximation = null;
-                maxInterpolError = 0.0;
                 extent = BoundingCube.EmptyBoundingCube;
                 tetraederHull = null;
                 extrema = null;
@@ -551,7 +549,6 @@ namespace CADability.GeoObject
                     bSpline.interpol = null;
                     bSpline.interdir = null;
                     bSpline.interparam = null;
-                    bSpline.maxInterpolError = 0.0;
                     if (!keepNurbs)
                     {
                         bSpline.nubs3d = null;

--- a/CADability/BSpline2D.cs
+++ b/CADability/BSpline2D.cs
@@ -606,7 +606,7 @@ namespace CADability.Curve2D
             {
                 Init();
             }
-            catch (NurbsException ne)
+            catch (NurbsException)
             {
             }
             // sollte durch Start/Endparameter nur ein Teilbereich des Splines gelten, dann

--- a/CADability/Block.cs
+++ b/CADability/Block.cs
@@ -751,7 +751,7 @@ namespace CADability.GeoObject
                 name = (string)info.GetValue("Name", typeof(string));
                 // FinishDeserialization.AddToContext(context,this);
             }
-            catch (SerializationException ex)
+            catch (SerializationException)
             {
                 SerializationInfoEnumerator e = info.GetEnumerator();
                 while (e.MoveNext())

--- a/CADability/BorderOperation.cs
+++ b/CADability/BorderOperation.cs
@@ -317,7 +317,7 @@ namespace CADability.Shapes
                     GeoVector2D dir2 = border2.DirectionAt(isp[j].par2).Normalized;
                     dirz = dir1.x * dir2.y - dir1.y * dir2.x;
                 }
-                catch (GeoVectorException e)
+                catch (GeoVectorException)
                 {
                     dirz = 0.0;
                 }

--- a/CADability/BorderQuadTree.cs
+++ b/CADability/BorderQuadTree.cs
@@ -717,7 +717,7 @@ namespace CADability.Shapes
                         position = BorderPosition.intersecting;
                         break;
                     }
-                    catch (CriticalPosition cp)
+                    catch (CriticalPosition)
                     {   // Korrekturwert für nächste Runde, wenn es einen Schnittpunkt genau auf einer Kante gab oder einen tangentialen Schnitt
                         center = center + korr;
                         width = width + korr.Length;

--- a/CADability/BoundingRect.cs
+++ b/CADability/BoundingRect.cs
@@ -12,7 +12,7 @@ namespace CADability
     /// so assignements always make a copy.
     /// </summary>
     [Serializable()]
-    public struct BoundingRect : IQuadTreeInsertable, IComparable<BoundingRect>, ISerializable
+    public struct BoundingRect : IQuadTreeInsertable, IComparable<BoundingRect>, ISerializable, IEquatable<BoundingRect>
     {
         public double Left;
         public double Right;
@@ -824,6 +824,27 @@ namespace CADability
         }
         #endregion
 
+        public bool Equals(BoundingRect other)
+        {
+            return Left.Equals(other.Left) && Right.Equals(other.Right) && Bottom.Equals(other.Bottom) && Top.Equals(other.Top);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is BoundingRect other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hashCode = Left.GetHashCode();
+                hashCode = (hashCode * 397) ^ Right.GetHashCode();
+                hashCode = (hashCode * 397) ^ Bottom.GetHashCode();
+                hashCode = (hashCode * 397) ^ Top.GetHashCode();
+                return hashCode;
+            }
+        }
     }
 
 }

--- a/CADability/ColorDef.cs
+++ b/CADability/ColorDef.cs
@@ -202,7 +202,7 @@ namespace CADability.Attribute
             {
                 color = (Color)info.GetValue("Color", typeof(Color));
             }
-            catch (Exception e)
+            catch (Exception)
             {
                 color = Color.Black;
             }

--- a/CADability/ColorSetting.cs
+++ b/CADability/ColorSetting.cs
@@ -73,7 +73,7 @@ namespace CADability
                 color = (Color)info.GetValue("Color", typeof(Color));
                 object dbg = info.GetValue("Color", typeof(object));
             }
-            catch (Exception e)
+            catch (Exception)
             {
                 color = Color.Black;
             }

--- a/CADability/ConstrHatchInside.cs
+++ b/CADability/ConstrHatchInside.cs
@@ -259,7 +259,7 @@ namespace CADability.Actions
                     {
                         findShapeThread.Abort();
                     }
-                    catch (System.Threading.ThreadStateException e)
+                    catch (System.Threading.ThreadStateException)
                     {
                         findShapeIsRunning = false;
                         return; // keinen weiteren thread starten
@@ -269,7 +269,7 @@ namespace CADability.Actions
                 {
                     findShapeThread.Join();
                 }
-                catch (System.Threading.ThreadStateException e)
+                catch (System.Threading.ThreadStateException)
                 {
                     findShapeIsRunning = false;
                     return; // keinen weiteren thread starten

--- a/CADability/ConstructAction.cs
+++ b/CADability/ConstructAction.cs
@@ -7137,7 +7137,7 @@ namespace CADability.Actions
          * in der Callback Methode ausführen. Dann kann man immer noch Escape drücken, wenns zu lange dauart (Vervielfältigen, Schraffur)
          */
         Thread backgroundTask;
-        bool finishedBackgroundTask;
+        bool finishedBackgroundTask, syncCallBack;
         Delegate CallbackOnDone;
         private void StartThread(object pars)
         {   // das läuft im background thread

--- a/CADability/ConstructAction.cs
+++ b/CADability/ConstructAction.cs
@@ -7137,7 +7137,7 @@ namespace CADability.Actions
          * in der Callback Methode ausführen. Dann kann man immer noch Escape drücken, wenns zu lange dauart (Vervielfältigen, Schraffur)
          */
         Thread backgroundTask;
-        bool finishedBackgroundTask, syncCallBack;
+        bool finishedBackgroundTask;
         Delegate CallbackOnDone;
         private void StartThread(object pars)
         {   // das läuft im background thread

--- a/CADability/CoordSys.cs
+++ b/CADability/CoordSys.cs
@@ -54,7 +54,7 @@ namespace CADability
                 directionY.Norm();
                 directionZ.Norm();
             }
-            catch (GeoVectorException e)
+            catch (GeoVectorException)
             {
                 throw new CoordSysException(CoordSysException.tExceptionType.ConstructorFailed);
             }

--- a/CADability/DualSurfaceCurve.cs
+++ b/CADability/DualSurfaceCurve.cs
@@ -615,7 +615,6 @@ namespace CADability
         BoundingRect periodicDomain; // only for periodic domains: to which period the 3d points should be mapped
         GeoPoint2D startPoint2d, endPoint2d;
         bool startPointIsPole, endPointIsPole;
-        bool spu, epu; // starting or ending pole in u
 #if DEBUG
         static int debugCounter = 0;
         private int debugCount; // to identify instance when debugging
@@ -704,14 +703,12 @@ namespace CADability
                     GeoPoint2D tmp = surface.PositionOf(curve3D.PointAt(0.1));
                     startPoint2d = new GeoPoint2D(us[i], tmp.y);
                     startPointIsPole = true;
-                    spu = true;
                 }
                 if ((pl | ep) < prec)
                 {
                     GeoPoint2D tmp = surface.PositionOf(curve3D.PointAt(0.9));
                     endPoint2d = new GeoPoint2D(us[i], tmp.y);
                     endPointIsPole = true;
-                    epu = true;
                 }
             }
             double[] vs = surface.GetVSingularities();
@@ -723,14 +720,12 @@ namespace CADability
                     GeoPoint2D tmp = surface.PositionOf(curve3D.PointAt(0.1));
                     startPoint2d = new GeoPoint2D(tmp.x, vs[i]);
                     startPointIsPole = true;
-                    spu = false;
                 }
                 if ((pl | ep) < prec*10)
                 {
                     GeoPoint2D tmp = surface.PositionOf(curve3D.PointAt(0.9));
                     endPoint2d = new GeoPoint2D(tmp.x, vs[i]);
                     endPointIsPole = true;
-                    epu = false;
                 }
             }
             if (forward)

--- a/CADability/Edge.cs
+++ b/CADability/Edge.cs
@@ -2713,7 +2713,7 @@ namespace CADability
                     Polyline pdbg = Polyline.Construct();
                     pdbg.SetPoints(pnts, false);
                 }
-                catch (PolylineException ex) { };
+                catch (PolylineException) { };
             }
 #endif
             if (curve3d != null) dist = Math.Max(dist, curve3d.DistanceTo(mp));

--- a/CADability/Ellipse2D.cs
+++ b/CADability/Ellipse2D.cs
@@ -756,7 +756,7 @@ namespace CADability.Curve2D
                 MinimizationResult mres = nm.FindMinimum(iof, new DenseVector(new double[] { position }));
                 return mres.MinimizingPoint[0];
             }
-            catch (Exception ex)
+            catch (Exception)
             {
                 return iof.Point[0];
             }

--- a/CADability/ExportToWebGl.cs
+++ b/CADability/ExportToWebGl.cs
@@ -1231,7 +1231,7 @@ namespace CADability
                     outfile.Close();
                 }
             }
-            catch (IOException e)
+            catch (IOException)
             {
                 return false;
             }

--- a/CADability/Face.cs
+++ b/CADability/Face.cs
@@ -6305,7 +6305,7 @@ namespace CADability.GeoObject
                     }
                 }
             }
-            catch (ApplicationException e)
+            catch (ApplicationException)
             {   // something went wrong with the triangulation. This should not happen and needs to be debugged and fixed
             }
             triangleExtent = BoundingCube.EmptyBoundingCube; // needs to be recalculated
@@ -6606,7 +6606,7 @@ namespace CADability.GeoObject
                 }
 #endif
             }
-            catch (ApplicationException e)
+            catch (ApplicationException)
             {   // Selbstüberschneidungen von Löchern und Rand oder in den Rändern selbst
                 List<GeoPoint2D> sumTriUv = new List<GeoPoint2D>();
                 List<GeoPoint> sumTriPoint = new List<GeoPoint>();

--- a/CADability/Filter.cs
+++ b/CADability/Filter.cs
@@ -468,7 +468,7 @@ namespace CADability.Attribute
                 }
                 return res;
             }
-            catch (System.Reflection.ReflectionTypeLoadException e)
+            catch (System.Reflection.ReflectionTypeLoadException)
             {
                 // MessageBox.Show(e.Message);
                 return new Dictionary<Type, string>();
@@ -770,7 +770,7 @@ namespace CADability.Attribute
                 {
                     Name = newValue;
                 }
-                catch (NameAlreadyExistsException e) { }
+                catch (NameAlreadyExistsException) { }
             }
         }
         public override string LabelText { get => Name; set => Name = value; }

--- a/CADability/GeneralCurve2D.cs
+++ b/CADability/GeneralCurve2D.cs
@@ -1627,7 +1627,7 @@ namespace CADability.Curve2D
                 if (directions[0].IsNullVector()) linterdir.Add((points[1] - points[0]).Normalized);
                 else linterdir.Add(directions[0].Normalized);
             }
-            catch (GeoVectorException ex)
+            catch (GeoVectorException)
             {
                 linterdir.Add(GeoVector2D.XAxis);
             }

--- a/CADability/LayerList.cs
+++ b/CADability/LayerList.cs
@@ -544,7 +544,7 @@ namespace CADability.Attribute
                     }
                 } while (found);
             }
-            catch (InvalidOperationException e)
+            catch (InvalidOperationException)
             {   // soll mal bei der Iteration vorgekommen sein (Mail vom 21.10 13, Nürnberger) kann ich mir aber nicht erklären
             }
         }

--- a/CADability/LayoutView.cs
+++ b/CADability/LayoutView.cs
@@ -129,7 +129,7 @@ namespace CADability
                 {
                     pd.Print();
                 }
-                catch (Exception e)
+                catch (Exception)
                 {
                 }
                 pd.PrintPage -= new PrintPageEventHandler(pdg.OnPrintPage);
@@ -141,7 +141,7 @@ namespace CADability
                 {
                     pd.Print();
                 }
-                catch (Exception e)
+                catch (Exception)
                 {
                 }
                 pd.PrintPage -= new PrintPageEventHandler(OnPrintPage);

--- a/CADability/MultiGeoPointProperty.cs
+++ b/CADability/MultiGeoPointProperty.cs
@@ -376,7 +376,7 @@ namespace CADability.UserInterface
                             break;
                     }
                 }
-                catch (IndexOutOfRangeException e)
+                catch (IndexOutOfRangeException)
                 {
                 }
             }

--- a/CADability/NurbsSurface.cs
+++ b/CADability/NurbsSurface.cs
@@ -1976,7 +1976,7 @@ namespace CADability.GeoObject
                     {
                         reparametrisation = ModOp2D.Fit(srcf, dstf, true);
                     }
-                    catch (ModOpException mex)
+                    catch (ModOpException)
                     {
                         return false;
                     }
@@ -2825,7 +2825,7 @@ namespace CADability.GeoObject
                         if (!isPlane) break;
                     }
                 }
-                catch (ModOpException mex)
+                catch (ModOpException)
                 {
                     isPlane = false;
                 }

--- a/CADability/Plane.cs
+++ b/CADability/Plane.cs
@@ -123,7 +123,7 @@ namespace CADability
             {
                 coordSys = new CoordSys(Location, DirectionX, DirectionY);
             }
-            catch (CoordSysException e)
+            catch (CoordSysException)
             {
                 throw new PlaneException(PlaneException.tExceptionType.ConstructorFailed);
             }

--- a/CADability/PrintToGDI.cs
+++ b/CADability/PrintToGDI.cs
@@ -663,7 +663,7 @@ namespace CADability
             {
                 ff = new FontFamily(fontName);
             }
-            catch (System.ArgumentException ae)
+            catch (System.ArgumentException)
             {
                 ff = new FontFamily(System.Drawing.Text.GenericFontFamilies.SansSerif);
             }
@@ -909,7 +909,7 @@ namespace CADability
                             GeoPoint2D ip = cs.SimpleShapes[0].Outline.SomeInnerPoint;
                             return ZPositionAt(ip).CompareTo((other as PrintTriangle).ZPositionAt(ip));
                         }
-                        catch (BorderException ex)
+                        catch (BorderException)
                         {
                             return 0;
                         }
@@ -1230,7 +1230,7 @@ namespace CADability
                     br.Dispose();
                 }
             }
-            catch (Exception ex)
+            catch (Exception)
             {
             }
 
@@ -1535,7 +1535,7 @@ namespace CADability
                     pd.PrintPage -= new PrintPageEventHandler(ptg.OnPrintPage);
                     (found as IView).Projection.ShowFaces = sf;
                 }
-            } catch (Exception ex)
+            } catch (Exception)
             {
                 // MessageBox.Show(ex.StackTrace, "Exception in PrintSinglePage");
             }
@@ -1844,7 +1844,7 @@ namespace CADability
                     e.Graphics.DrawImage(bmp, dest, src, GraphicsUnit.Pixel);
                 }
             }
-            catch (Exception ex)
+            catch (Exception)
             {
                 // MessageBox.Show(ex.StackTrace, "Exception in OnPrintPage");
             }
@@ -2488,7 +2488,7 @@ namespace CADability
                 {
                     ff = new FontFamily(fontName);
                 }
-                catch (System.ArgumentException ae)
+                catch (System.ArgumentException)
                 {
                     ff = new FontFamily(System.Drawing.Text.GenericFontFamilies.SansSerif);
                 }

--- a/CADability/Project.cs
+++ b/CADability/Project.cs
@@ -1472,7 +1472,7 @@ namespace CADability
                 }
                 return null;
             }
-            catch (Exception e)
+            catch (Exception)
             {
                 formatter = new BinaryFormatter(); // (null, new StreamingContext(StreamingContextStates.File, finishDeserialization));
                 formatter.Binder = new CondorSerializationBinder();
@@ -1603,7 +1603,7 @@ namespace CADability
                     }
                     res.fileName = FileName;
                 }
-                catch (ProjectOldVersionException ex)
+                catch (ProjectOldVersionException)
                 {
                     stream.Close();
                     stream.Dispose();

--- a/CADability/Projection.cs
+++ b/CADability/Projection.cs
@@ -1548,7 +1548,7 @@ namespace CADability
                     res.Add(Face.MakeFace(new PlaneSurface(arrowPlane), new SimpleShape(Border.MakeCircle(GeoPoint2D.Origin, arrowSize))));
                     res.Add(Face.MakeFace(new PlaneSurface(arrowPlane), new SimpleShape(Border.MakePolygon(new GeoPoint2D[] { new GeoPoint2D(headx, 0), new GeoPoint2D(headx - arrowSize, arrowSize), new GeoPoint2D(headx - arrowSize, -arrowSize) }))));
                 }
-                catch (PlaneException _) { }
+                catch (PlaneException) { }
             }
             return res;
         }

--- a/CADability/Shell.cs
+++ b/CADability/Shell.cs
@@ -312,7 +312,7 @@ namespace CADability.GeoObject
                         double a = cp.Length / 2.0; // area of the triangle
                         corr += a * d * 3 / 4; // 3/4 is a good value for spheres and cylinders
                     }
-                    catch (PlaneException pe) { }
+                    catch (PlaneException) { }
                 }
             }
             return sum / 6 + corr;
@@ -700,7 +700,7 @@ namespace CADability.GeoObject
                                 }
                             }
                         }
-                        catch (Exception ex) { }
+                        catch (Exception) { }
                     }
                     backSide.Clear();
                     if (bestFace != null) backSide.Add(bestFace);

--- a/CADability/SphericalSurfaceNP.cs
+++ b/CADability/SphericalSurfaceNP.cs
@@ -194,7 +194,7 @@ namespace CADability.GeoObject
             {
                 return Plane.XYPlane.Intersect(beam); // intersection of XY plane
             }
-            catch (PlaneException pe)
+            catch (PlaneException)
             {
                 return GeoPoint2D.Invalid;
             }

--- a/CADability/Surface.cs
+++ b/CADability/Surface.cs
@@ -3227,7 +3227,7 @@ namespace CADability.GeoObject
                 {
                     b2d = new BSpline2D(through, 3, Precision.IsEqual(through[0], through[through.Length - 1])); //  curve.IsClosed);
                 }
-                catch (NurbsException ne)
+                catch (NurbsException)
                 {
                     List<GeoPoint2D> cleanThroughPoints = new List<GeoPoint2D>();
                     cleanThroughPoints.Add(through[0]);
@@ -9165,7 +9165,7 @@ namespace CADability.GeoObject
                             dbgl.Add(pl);
                         }
                     }
-                    catch (PolylineException ex)
+                    catch (PolylineException)
                     { }
                 }
                 dbgl.Add(Line.TwoPoints(cube.pll, cube.pll + 10 * cube.nll));

--- a/CADability/TestsWithMathNet.cs
+++ b/CADability/TestsWithMathNet.cs
@@ -138,7 +138,7 @@ namespace CADability
                 // mres.FunctionInfoAtMinimum.Value;
                 return true;
             }
-            catch (Exception e)
+            catch (Exception)
             {
                 return false;
             }
@@ -178,7 +178,7 @@ namespace CADability
                 ip = lastIp;
                 return true;
             }
-            catch (Exception e)
+            catch (Exception)
             {
                 ip = GeoPoint.Origin;
                 return false;
@@ -622,7 +622,7 @@ namespace CADability
                     return true;
                 }
             }
-            catch (Exception ex)
+            catch (Exception)
             {
             }
             normal = GeoVector.NullVector;

--- a/CADability/ToolsRoundMultiple.cs
+++ b/CADability/ToolsRoundMultiple.cs
@@ -188,7 +188,7 @@ namespace CADability.Actions
                     }
                 }
             }
-            catch (ApplicationException e)
+            catch (ApplicationException)
             {
                 return false;
             }

--- a/CADability/ToroidalSurface.cs
+++ b/CADability/ToroidalSurface.cs
@@ -457,7 +457,7 @@ namespace CADability.GeoObject
                     }
                 }
             }
-            catch (ApplicationException ex) { }
+            catch (ApplicationException) { }
             return sol.ToArray();
         }
         /// <summary>


### PR DESCRIPTION
The majority of these were just unused variables in try/catch blocks. This should clear almost 50 compiler warnings. The biggest change is implementing IEquatable on the BoundingRect class. I probably should have made that a separate PR but I'm still getting the hang of organizing my commits in branches for clean PRs. I'm very much open to critique to make my PRs easier to accept.