### PR TITLE
Add `SetCoefficients` call to `SetPlacement(double factor, double dx, double dy)` in Projection

### DIFF
--- a/CADability/Projection.cs
+++ b/CADability/Projection.cs
@@ -706,6 +706,7 @@ namespace CADability
             placementFactor = factor;
             placementX = dx;
             placementY = dy;
+            SetCoefficients();
         }
         /// <summary>
         /// Liefert die Werte für die Platzierung. Achtung: die Y-Werte müssen mit dem negativen


### PR DESCRIPTION
This Pull Request adds a call to `SetCoefficients()` in the `SetPlacement(double factor, double dx, double dy)` method. This ensures that updates to placement parameters are correctly reflected in the coefficients, and makes the behavior consistant with other `SetPlacement` overloads, `MovePlacement`, etc.