### PR TITLE
Fix CS3005 - Identifier 'identifier' differing only in case is not CL…

### DIFF
--- a/CADability/netDxf/GTE/BSplineSurface.cs
+++ b/CADability/netDxf/GTE/BSplineSurface.cs
@@ -54,10 +54,10 @@ namespace netDxf.GTE
             this.numControls = new[] {input0.NumControls, input1.NumControls};
 
             // The mBasisFunction stores the domain but so does ParametricCurve.
-            this.uMin = this.basisFunctions[0].MinDomain;
-            this.uMax = this.basisFunctions[0].MaxDomain;
-            this.vMin = this.basisFunctions[1].MinDomain;
-            this.vMax = this.basisFunctions[1].MaxDomain;
+            UMin = this.basisFunctions[0].MinDomain;
+            UMax = this.basisFunctions[0].MaxDomain;
+            VMin = this.basisFunctions[1].MinDomain;
+            VMax = this.basisFunctions[1].MaxDomain;
 
             // The replication of control points for periodic splines is
             // avoided by wrapping the i-loop index in Evaluate.
@@ -67,7 +67,7 @@ namespace netDxf.GTE
                 controls.CopyTo(this.controls, 0);
             }
 
-            this.isConstructed = true;
+            IsConstructed  = true;
         }
 
         // Member access.  The index 'dim' must be in {0,1}.
@@ -115,10 +115,10 @@ namespace netDxf.GTE
         // u and v [0,1]
         public override void Evaluate(double u, double v, int order, out Vector3[] jet)
         {
-            int supOrder = SUP_ORDER;
+            int supOrder = SupOrder;
             jet = new Vector3[supOrder];
 
-            if (!this.isConstructed || order >= supOrder)
+            if (!IsConstructed || order >= supOrder)
             {
                 // Return a zero-valued jet for invalid state.
                 return;

--- a/CADability/netDxf/GTE/NURBSSurface.cs
+++ b/CADability/netDxf/GTE/NURBSSurface.cs
@@ -56,10 +56,10 @@ namespace netDxf.GTE
             this.numControls = new[] {input0.NumControls, input1.NumControls};
 
             // The mBasisFunction stores the domain but so does ParametricSurface.
-            this.uMin = this.basisFunctions[0].MinDomain;
-            this.uMax = this.basisFunctions[0].MaxDomain;
-            this.vMin = this.basisFunctions[1].MinDomain;
-            this.vMax = this.basisFunctions[1].MaxDomain;
+            UMin = this.basisFunctions[0].MinDomain;
+            UMax = this.basisFunctions[0].MaxDomain;
+            VMin = this.basisFunctions[1].MinDomain;
+            VMax = this.basisFunctions[1].MaxDomain;
 
             // The replication of control points for periodic splines is
             // avoided by wrapping the i-loop index in Evaluate.
@@ -75,7 +75,7 @@ namespace netDxf.GTE
                 weights.CopyTo(this.weights, 0);
             }
 
-            this.isConstructed = true;
+            IsConstructed = true;
         }
 
         // Member access.  The index 'dim' must be in {0,1}.
@@ -145,10 +145,10 @@ namespace netDxf.GTE
         // d2X/dudv, d2X/dv2.
         public override void Evaluate(double u, double v, int order, out Vector3[] jet)
         {
-            const int supOrder = SUP_ORDER;
+            const int supOrder = SupOrder;
             jet = new Vector3[supOrder];
 
-            if (!this.isConstructed || order >= supOrder)
+            if (!IsConstructed || order >= supOrder)
             {
                 // Return a zero-valued jet for invalid state.
                 return;

--- a/CADability/netDxf/GTE/ParametricSurface.cs
+++ b/CADability/netDxf/GTE/ParametricSurface.cs
@@ -36,10 +36,6 @@ namespace netDxf.GTE
 {
     public abstract class ParametricSurface
     {
-        protected double uMin, uMax, vMin, vMax;
-        protected bool isRectangular;
-        protected bool isConstructed;
-
         // Abstract base class for a parameterized surface X(u,v).  The
         // parametric domain is either rectangular or triangular.  Valid
         // (u,v) values for a rectangular domain satisfy
@@ -49,12 +45,12 @@ namespace netDxf.GTE
         //   (vmax-vmin)*(u-umin)+(umax-umin)*(v-vmax) <= 0
         protected ParametricSurface(double umin, double umax, double vmin, double vmax, bool isRectangular)
         {
-            this.uMin = umin;
-            this.uMax = umax;
-            this.vMin = vmin;
-            this.vMax = vmax;
-            this.isRectangular = isRectangular;
-            this.isConstructed = false;
+            UMin = umin;
+            UMax = umax;
+            VMin = vmin;
+            VMax = vmax;
+            IsRectangular = isRectangular;
+            IsConstructed = false;
         }
 
         // Member access.
@@ -62,35 +58,17 @@ namespace netDxf.GTE
         // To validate construction, create an object as shown:
         //     DerivedClassSurface<Real> surface(parameters);
         //     if (!surface) { <constructor failed, handle accordingly>; }
-        public bool IsConstructed
-        {
-            get { return this.isConstructed; }
-        }
+        public bool IsConstructed { get; protected set; }
 
-        public double UMin
-        {
-            get { return this.uMin; }
-        }
+        public double UMin { get; protected set; }
 
-        public double UMax
-        {
-            get { return this.uMax; }
-        }
+        public double UMax { get; protected set; }
 
-        public double VMin
-        {
-            get { return this.vMin; }
-        }
+        public double VMin { get; protected set; }
 
-        public double VMax
-        {
-            get { return this.vMax; }
-        }
+        public double VMax { get; protected set; }
 
-        public bool IsIsRectangular
-        {
-            get { return this.isRectangular; }
-        }
+        public bool IsRectangular { get; protected set; }
 
         // Evaluation of the surface.  The function supports derivative
         // calculation through order 2; that is, order <= 2 is required.  If
@@ -100,7 +78,7 @@ namespace netDxf.GTE
         // maximum order.  The values are ordered as: position X; first-order
         // derivatives dX/du, dX/dv; second-order derivatives d2X/du2,
         // d2X/dudv, d2X/dv2.
-        public const int SUP_ORDER = 6;
+        public const int SupOrder = 6;
 
         public abstract void Evaluate(double u, double v, int order, out Vector3[] jet);
 


### PR DESCRIPTION
Fix CS3005 - Identifier 'identifier' differing only in case is not CLS-compliant

for ParametricSurface and depending classes