### PR TITLE
Fix CS3006 - Overloaded method 'method' differing only in ref or out,…

### DIFF
--- a/CADability/Arc2D.cs
+++ b/CADability/Arc2D.cs
@@ -300,7 +300,7 @@ namespace CADability.Curve2D
             {   // 19.8.15: bin nicht sicher, ob das mit negativem sweep auch geht, deshalb hier umdrehen
                 return (new Arc2D(Center, Radius, start + sweep, -sweep)).HitTest(ref Rect, IncludeControlPoints);
             }
-            ClipRect clr = new ClipRect(ref Rect);
+            ClipRect clr = new ClipRect(Rect);
 
             int StartQuadrant = start.Quadrant;
             int EndQuadrant = (start + sweep).Quadrant;

--- a/CADability/Bitmap.cs
+++ b/CADability/Bitmap.cs
@@ -381,7 +381,7 @@ namespace CADability.GeoObject
             }
             else
             {
-                ClipRect clr = new ClipRect(ref rect);
+                ClipRect clr = new ClipRect(rect);
                 return clr.ParallelogramHitTest(projection.ProjectUnscaled(location), projection.ProjectUnscaled(directionWidth), projection.ProjectUnscaled(directionHeight));
             }
         }

--- a/CADability/BoundingCube.cs
+++ b/CADability/BoundingCube.cs
@@ -930,7 +930,7 @@ namespace CADability
         /// <returns>ture if interference, false otherwise</returns>
         public bool Interferes(Projection projection, BoundingRect rect)
         {
-            ClipRect clr = new ClipRect(ref rect);
+            ClipRect clr = new ClipRect(rect);
             GeoPoint2D[] points2d = new GeoPoint2D[]{
                 projection.ProjectUnscaled(new GeoPoint(Xmin, Ymin, Zmin)),
                 projection.ProjectUnscaled(new GeoPoint(Xmax, Ymin, Zmin)),

--- a/CADability/Circle2D.cs
+++ b/CADability/Circle2D.cs
@@ -298,7 +298,7 @@ namespace CADability.Curve2D
         /// <returns></returns>
         public override bool HitTest(ref BoundingRect Rect, bool IncludeControlPoints)
         {
-            ClipRect clr = new ClipRect(ref Rect);
+            ClipRect clr = new ClipRect(Rect);
             if (clr.ArcHitTest(center, radius, 0, new GeoPoint2D(center.x + radius, center.y), new GeoPoint2D(center.x, center.y + radius))) return true;
             if (clr.ArcHitTest(center, radius, 1, new GeoPoint2D(center.x, center.y + radius), new GeoPoint2D(center.x - radius, center.y))) return true;
             if (clr.ArcHitTest(center, radius, 2, new GeoPoint2D(center.x - radius, center.y), new GeoPoint2D(center.x, center.y - radius))) return true;

--- a/CADability/ClipRect.cs
+++ b/CADability/ClipRect.cs
@@ -38,13 +38,6 @@ namespace CADability
             else if (p.y > Top) res = res | ClipTop;
             return res;
         }
-        public ClipRect(ref BoundingRect r)
-        {	// warum mit ref???
-            Left = r.Left;
-            Right = r.Right;
-            Bottom = r.Bottom;
-            Top = r.Top;
-        }
         public ClipRect(BoundingRect r)
         {
             Left = r.Left;

--- a/CADability/DebuggerContainer.cs
+++ b/CADability/DebuggerContainer.cs
@@ -324,6 +324,8 @@ namespace CADability
             res.Add(pl);
             return res;
         }
+
+        [CLSCompliant(false)]
         public static DebuggerContainer Show(GeoPoint[,] points)
         {
             DebuggerContainer res = new DebuggerContainer();

--- a/CADability/Ellipse2D.cs
+++ b/CADability/Ellipse2D.cs
@@ -384,7 +384,7 @@ namespace CADability.Curve2D
             Angle majorang = majorAxis.Angle;
             double radiusx = majorAxis.Length;
             double radiusy = minorAxis.Length;
-            ClipRect clr = new ClipRect(ref Rect);
+            ClipRect clr = new ClipRect(Rect);
             if (clr.EllipseArcHitTest(center, radiusx, radiusy, majorang, 0, right, top)) return true;
             if (clr.EllipseArcHitTest(center, radiusx, radiusy, majorang, 1, top, left)) return true;
             if (clr.EllipseArcHitTest(center, radiusx, radiusy, majorang, 2, left, bottom)) return true;

--- a/CADability/EllipseArc2D.cs
+++ b/CADability/EllipseArc2D.cs
@@ -200,7 +200,7 @@ namespace CADability.Curve2D
             Angle majorang = majorAxis.Angle;
             double radiusx = majorAxis.Length;
             double radiusy = minorAxis.Length;
-            ClipRect clr = new ClipRect(ref Rect);
+            ClipRect clr = new ClipRect(Rect);
             if (clr.Contains(startPoint)) return true;
             if (clr.Contains(EndPoint)) return true;
 

--- a/CADability/Face.cs
+++ b/CADability/Face.cs
@@ -5699,7 +5699,7 @@ namespace CADability.GeoObject
                     }
                     else
                     {
-                        ClipRect clr = new ClipRect(ref rect);
+                        ClipRect clr = new ClipRect(rect);
                         return clr.TriangleHitTest(p1, p2, p3);
                     }
                 }
@@ -7236,7 +7236,7 @@ namespace CADability.GeoObject
         public override bool HitTest(Projection projection, BoundingRect rect, bool onlyInside)
         {
             if (trianglePoint == null) return false; // this is only for selecting with the mouse
-            ClipRect clr = new ClipRect(ref rect);
+            ClipRect clr = new ClipRect(rect);
             if (onlyInside)
             {
                 lock (lockTriangulationData)

--- a/CADability/GeneralCurve2D.cs
+++ b/CADability/GeneralCurve2D.cs
@@ -3637,7 +3637,7 @@ namespace CADability.Curve2D
         }
         public virtual bool HitTest(ref BoundingRect rect, bool includeControlPoints)
         {
-            ClipRect clr = new ClipRect(ref rect);
+            ClipRect clr = new ClipRect(rect);
             if (interpol == null) MakeTriangulation();
             for (int i = 0; i < interpol.Length - 1; ++i)
             {

--- a/CADability/Line.cs
+++ b/CADability/Line.cs
@@ -328,7 +328,7 @@ namespace CADability.GeoObject
             }
             else
             {
-                ClipRect clr = new ClipRect(ref rect);
+                ClipRect clr = new ClipRect(rect);
                 return clr.LineHitTest(projection.ProjectUnscaled(startPoint), projection.ProjectUnscaled(endPoint));
             }
         }
@@ -971,7 +971,7 @@ namespace CADability.GeoObject
 
         bool IQuadTreeInsertable.HitTest(ref BoundingRect rect, bool includeControlPoints)
         {
-            ClipRect clr = new ClipRect(ref rect);
+            ClipRect clr = new ClipRect(rect);
             return clr.LineHitTest(sp, ep);
         }
 
@@ -1013,7 +1013,7 @@ namespace CADability.GeoObject
             }
             else
             {
-                ClipRect clr = new ClipRect(ref rect);
+                ClipRect clr = new ClipRect(rect);
                 // eine Linie machen, die bestimmt über das rechteck hinaus geht
                 GeoPoint2D sp2d = projection.ProjectUnscaled(start);
                 GeoVector2D dir2d = projection.ProjectUnscaled(dir);
@@ -1080,7 +1080,7 @@ namespace CADability.GeoObject
             }
             else
             {
-                ClipRect clr = new ClipRect(ref rect);
+                ClipRect clr = new ClipRect(rect);
                 // eine Linie machen, die bestimmt über das rechteck hinaus geht
                 GeoPoint2D sp2d = projection.ProjectUnscaled(start);
                 GeoVector2D dir2d = projection.ProjectUnscaled(dir);

--- a/CADability/Line2D.cs
+++ b/CADability/Line2D.cs
@@ -34,7 +34,7 @@ namespace CADability.Curve2D
             double l = clippedBy.Width + clippedBy.Height;
             startPoint = c + l * direction;
             endPoint = c - l * direction;
-            ClipRect clr = new ClipRect(ref clippedBy);
+            ClipRect clr = new ClipRect(clippedBy);
             clr.ClipLine(ref startPoint, ref endPoint);
         }
         public override string ToString()
@@ -188,7 +188,7 @@ namespace CADability.Curve2D
         /// <returns></returns>
 		public override bool HitTest(ref BoundingRect Rect, bool IncludeControlPoints)
         {
-            ClipRect clr = new ClipRect(ref Rect);
+            ClipRect clr = new ClipRect(Rect);
             return clr.LineHitTest(startPoint, endPoint);
         }
         /// <summary>

--- a/CADability/Polyline.cs
+++ b/CADability/Polyline.cs
@@ -1721,7 +1721,7 @@ namespace CADability.GeoObject
 
         bool IOctTreeInsertable.HitTest(Projection projection, BoundingRect rect, bool onlyInside)
         {
-            ClipRect clr = new ClipRect(ref rect);
+            ClipRect clr = new ClipRect(rect);
             for (int i = 1; i < vertex.Length - 3; ++i)
             {
                 if (clr.LineHitTest(projection.ProjectUnscaled(vertex[i]), projection.ProjectUnscaled(vertex[i + 1]))) return true;

--- a/CADability/Polyline2D.cs
+++ b/CADability/Polyline2D.cs
@@ -263,7 +263,7 @@ namespace CADability.Curve2D
         /// <returns></returns>
         public override bool HitTest(ref BoundingRect Rect, bool IncludeControlPoints)
         {
-            ClipRect clr = new ClipRect(ref Rect);
+            ClipRect clr = new ClipRect(Rect);
             for (int i = 1; i < vertex.Length; ++i)
             {
                 GeoPoint2D sp = vertex[i - 1];

--- a/CADability/Surface.cs
+++ b/CADability/Surface.cs
@@ -6515,7 +6515,7 @@ namespace CADability.GeoObject
                             double f = (axloc.y - domain1.Top) / axdir.y;
                             p2 = p2 - f * axdir;
                         }
-                        ClipRect clr = new ClipRect(ref domain1);
+                        ClipRect clr = new ClipRect(domain1);
                         if (clr.ClipLine(ref p1, ref p2))
                         {
                             GeoPoint2D pm = new GeoPoint2D(p1, p2);

--- a/CADability/Text.cs
+++ b/CADability/Text.cs
@@ -3112,7 +3112,7 @@ namespace CADability.GeoObject
             }
             else
             {
-                ClipRect clr = new ClipRect(ref rect);
+                ClipRect clr = new ClipRect(rect);
                 // nicht sicher, object die folgenden noch skaliert werden müssen:
                 return clr.ParallelogramHitTest(projection.ProjectUnscaled(lowerLeft), projection.ProjectUnscaled(lowerRight - lowerLeft), projection.ProjectUnscaled(upperLeft - lowerLeft));
             }

--- a/CADability/Triangulation.cs
+++ b/CADability/Triangulation.cs
@@ -279,7 +279,7 @@ namespace CADability
 
             bool IQuadTreeInsertable.HitTest(ref BoundingRect rect, bool includeControlPoints)
             {
-                ClipRect clr = new ClipRect(ref rect);
+                ClipRect clr = new ClipRect(rect);
                 return clr.LineHitTest(vertex[edge.v1].p2d, vertex[edge.v2].p2d);
             }
 


### PR DESCRIPTION
… or in array rank, is not CLS-compliant

#49