### PR TITLE
Fixed getting user attributes (which were previously set via 'IGeoObject.SetNamedAttribute')

### DIFF
--- a/CADability/GeoObject.cs
+++ b/CADability/GeoObject.cs
@@ -1,4 +1,4 @@
-﻿using CADability.UserInterface;
+using CADability.UserInterface;
 using System;
 using System.Collections;
 using System.Reflection;
@@ -1172,7 +1172,7 @@ namespace CADability.GeoObject
                 attributes.Add((this as IStyle).Style);
             if (userAttributes != null)
             {
-                foreach (INamedAttribute na in userAttributes)
+                foreach (INamedAttribute na in userAttributes.Values)
                     attributes.Add(na);
             }
             for (int i = 0; i < NumChildren; i++)

--- a/CADability/GeoObject.cs
+++ b/CADability/GeoObject.cs
@@ -1,4 +1,4 @@
-using CADability.UserInterface;
+﻿using CADability.UserInterface;
 using System;
 using System.Collections;
 using System.Reflection;


### PR DESCRIPTION
### This pull request fixes retrieving custom user attributes, when calling the getter of 'IGeoObject.Attributes'

Custom user attributes are internally stored in a SortedList with Keys and Values and therefore the actual attributes need to be retrieved via the 'Values' to avoid a CastException.