### PR TITLE
Providing 'PreferredStyle' for 'Path' + not removing embedded resource files

### DIFF
--- a/CADability/CADability.csproj
+++ b/CADability/CADability.csproj
@@ -49,9 +49,6 @@
     <RemoveFiles Include="Tangulation.cs" />
 
     <RemoveFiles Include="log.txt" />
-    <RemoveFiles Include="MenuResource.xml" />
-    <RemoveFiles Include="StringTableDeutsch.xml" />
-    <RemoveFiles Include="StringTableEnglish.xml" />
     <RemoveFiles Include="_ToDo.txt" />
 
     <RemoveFiles Include="WebDrawing.cs" Condition="'$(Configuration)'!='WebDebug'"/>

--- a/CADability/Path.cs
+++ b/CADability/Path.cs
@@ -1,4 +1,4 @@
-﻿using CADability.Attribute;
+using CADability.Attribute;
 using CADability.Curve2D;
 using CADability.UserInterface;
 using System;
@@ -1151,13 +1151,20 @@ namespace CADability.GeoObject
                 return res.ToArray();
             }
         }
-        #region IGeoObjectImpl
-        /// <summary>
-        /// Overrides <see cref="CADability.GeoObject.IGeoObjectImpl.GetShowProperties (IFrame)"/>
-        /// </summary>
-        /// <param name="Frame"></param>
-        /// <returns></returns>
-        public override IPropertyEntry GetShowProperties(IFrame Frame)
+		#region IGeoObjectImpl
+		public override Style.EDefaultFor PreferredStyle
+		{
+			get
+			{
+				return Style.EDefaultFor.Curves;
+			}
+		}
+		/// <summary>
+		/// Overrides <see cref="CADability.GeoObject.IGeoObjectImpl.GetShowProperties (IFrame)"/>
+		/// </summary>
+		/// <param name="Frame"></param>
+		/// <returns></returns>
+		public override IPropertyEntry GetShowProperties(IFrame Frame)
         {
             return new ShowPropertyPath(this, Frame);
         }


### PR DESCRIPTION
### This pull request includes two fixes:
1. For `Path` geometry, the `PreferredStyle` is now correctly provided - to apply the same Style applied to other geometry inheriting from `ICurve` (*Exactly the same value as for `Line`, `Ellipse`, `Polyline`, `BSpline`, ...*)
2. The embedded resources accidently removed from build (previous PR) are correctly included again