### PR TITLE
Fix Warning CS3005

### DIFF
--- a/CADability/netDxf/BezierCurve.cs
+++ b/CADability/netDxf/BezierCurve.cs
@@ -34,13 +34,6 @@ namespace netDxf
     /// </summary>
     public abstract class BezierCurve
     {
-        #region private fields
-
-        protected readonly Vector3[] controlPoints;
-        protected readonly int degree;
-
-        #endregion
-
         #region constructors
 
         /// <summary>
@@ -62,10 +55,10 @@ namespace netDxf
                 throw new ArgumentOutOfRangeException(nameof(degree), degree, "The bezier curve degree must be at least one.");
             }
 
-            this.controlPoints = controlPoints.ToArray();
-            this.degree = degree;
+            this.ControlPoints = controlPoints.ToArray();
+            this.Degree = degree;
             
-            if (this.degree != this.controlPoints.Length - 1)
+            if (this.Degree != ControlPoints.Length - 1)
             {
                 throw new ArgumentException("The bezier curve degree must be equal to the number of control points minus one.");
             }
@@ -78,18 +71,12 @@ namespace netDxf
         /// <summary>
         /// Gets the control points.
         /// </summary>
-        public Vector3[] ControlPoints
-        {
-            get { return this.controlPoints; }
-        }
+        public Vector3[] ControlPoints { get; }
 
         /// <summary>
         /// Gets the bezier curve degree.
         /// </summary>
-        public int Degree
-        {
-            get { return this.degree; }
-        }
+        public int Degree { get; }
 
         #endregion
 

--- a/CADability/netDxf/BezierCurveCubic.cs
+++ b/CADability/netDxf/BezierCurveCubic.cs
@@ -74,8 +74,8 @@ namespace netDxf
         /// </summary>
         public Vector3 StartPoint
         {
-            get { return this.controlPoints[0]; }
-            set { this.controlPoints[0] = value; }
+            get { return ControlPoints[0]; }
+            set { ControlPoints[0] = value; }
         }
 
         /// <summary>
@@ -83,8 +83,8 @@ namespace netDxf
         /// </summary>
         public Vector3 FirstControlPoint
         {
-            get { return this.controlPoints[1]; }
-            set { this.controlPoints[1] = value; }
+            get { return ControlPoints[1]; }
+            set { ControlPoints[1] = value; }
         }
 
         /// <summary>
@@ -92,8 +92,8 @@ namespace netDxf
         /// </summary>
         public Vector3 SecondControlPoint
         {
-            get { return this.controlPoints[2]; }
-            set { this.controlPoints[2] = value; }
+            get { return ControlPoints[2]; }
+            set { ControlPoints[2] = value; }
         }
 
         /// <summary>
@@ -101,8 +101,8 @@ namespace netDxf
         /// </summary>
         public Vector3 EndPoint
         {
-            get { return this.controlPoints[3]; }
-            set { this.controlPoints[3] = value; }
+            get { return ControlPoints[3]; }
+            set { ControlPoints[3] = value; }
         }
 
         #endregion
@@ -174,7 +174,7 @@ namespace netDxf
         /// </summary>
         public void Reverse()
         {
-            Array.Reverse(this.controlPoints);
+            Array.Reverse(ControlPoints);
         }
 
         /// <summary>

--- a/CADability/netDxf/BezierCurveQuadratic.cs
+++ b/CADability/netDxf/BezierCurveQuadratic.cs
@@ -71,8 +71,8 @@ namespace netDxf
         /// </summary>
         public Vector3 StartPoint
         {
-            get { return this.controlPoints[0]; }
-            set { this.controlPoints[0] = value; }
+            get { return ControlPoints[0]; }
+            set { ControlPoints[0] = value; }
         }
 
         /// <summary>
@@ -80,8 +80,8 @@ namespace netDxf
         /// </summary>
         public Vector3 ControlPoint
         {
-            get { return this.controlPoints[1]; }
-            set { this.controlPoints[1] = value; }
+            get { return ControlPoints[1]; }
+            set { ControlPoints[1] = value; }
         }
 
         /// <summary>
@@ -89,8 +89,8 @@ namespace netDxf
         /// </summary>
         public Vector3 EndPoint
         {
-            get { return this.controlPoints[2]; }
-            set { this.controlPoints[2] = value; }
+            get { return ControlPoints[2]; }
+            set { ControlPoints[2] = value; }
         }
 
         #endregion
@@ -157,7 +157,7 @@ namespace netDxf
         /// </summary>
         public void Reverse()
         {
-            Array.Reverse(this.controlPoints);
+            Array.Reverse(ControlPoints);
         }
 
         /// <summary>


### PR DESCRIPTION
#49

CS3005	Identifier 'BezierCurve.ControlPoints' differing only in case is not CLS-compliant
