### PR TITLE
MultipleChoiceProperty SelectedText property

### DIFF
--- a/CADability/BooleanProperty.cs
+++ b/CADability/BooleanProperty.cs
@@ -57,8 +57,8 @@ namespace CADability.UserInterface
             MethodInfo mi = propertyInfo.GetGetMethod();
             object[] prm = new Object[0];
             bool val = (bool)mi.Invoke(objectWithProperty, prm);
-            if (val) selectedText = BooleanTextTrue;
-            else selectedText = BooleanTextFalse;
+            if (val) SelectedText = BooleanTextTrue;
+            else SelectedText = BooleanTextFalse;
         }
         public delegate void SetBooleanDelegate(bool val);
         public delegate bool GetBooleanDelegate();
@@ -108,7 +108,7 @@ namespace CADability.UserInterface
             }
             base.choices = new string[] { BooleanTextTrue, BooleanTextFalse };
             base.propertyLabelText = StringTable.GetString(resourceId + ".Label");
-            selectedText = BooleanTextTrue;
+            SelectedText = BooleanTextTrue;
         }
         /// <summary>
         /// Erzeugt eine BooleanProperty, welches einen eigenen boolean Wert enthält und

--- a/CADability/ColorSelectionProperty.cs
+++ b/CADability/ColorSelectionProperty.cs
@@ -29,11 +29,11 @@ namespace CADability.UserInterface
             ExtendChoices();
             if (select != null)
             {
-                selectedText = select.Name;
+                SelectedText = select.Name;
             }
             else
             {
-                selectedText = unselectedText;
+                SelectedText = unselectedText;
             }
             unselectedText = StringTable.GetString("ColorDef.Undefined");
             showUnselectedGray = true;
@@ -51,11 +51,11 @@ namespace CADability.UserInterface
             ExtendChoices();
             if (selectedColor != null)
             {
-                selectedText = selectedColor.Name;
+                SelectedText = selectedColor.Name;
             }
             else
             {
-                selectedText = unselectedText;
+                SelectedText = unselectedText;
             }
             toWatch = iColorDef as IGeoObject; // may be null
             showUnselectedGray = true;
@@ -96,7 +96,7 @@ namespace CADability.UserInterface
             ColorDef selectedColor = (ColorDef)mi.Invoke(objectWithProperty, prm);
             if (selectedColor != null)
             {
-                selectedText = selectedColor.Name;
+                SelectedText = selectedColor.Name;
             }
             selectedCD = selectedColor;
             clrTable.Usage = flags;
@@ -160,10 +160,10 @@ namespace CADability.UserInterface
             }
             if (selectedColor != null)
             {
-                selectedText = selectedColor.Name;
+                SelectedText = selectedColor.Name;
             }
             else if (selectedCD != null)
-                selectedText = selectedCD.Name;
+                SelectedText = selectedCD.Name;
         }
         public delegate void ColorDefChangedDelegate(ColorDef selected);
         public event ColorDefChangedDelegate ColorDefChangedEvent;

--- a/CADability/DimensionStyleSelectionProperty.cs
+++ b/CADability/DimensionStyleSelectionProperty.cs
@@ -57,8 +57,8 @@ namespace CADability.UserInterface
                 // sollte es den Namen schon geben, werden solange - davor und dahintergemacht, bis es den Namen mehr gibt
                 // while (Find(undef)!=null) undef = "-" + undef +"-";
                 choices[0] = undef;
-                if (dimensionStyle.DimensionStyle != null) selectedText = dimensionStyle.DimensionStyle.Name;
-                else selectedText = undef;
+                if (dimensionStyle.DimensionStyle != null) SelectedText = dimensionStyle.DimensionStyle.Name;
+                else SelectedText = undef;
             }
             else
             {
@@ -67,7 +67,7 @@ namespace CADability.UserInterface
                 {
                     base.choices[i] = selectableStyles[i].Name;
                 }
-                if (dimensionStyle.DimensionStyle != null) base.selectedText = dimensionStyle.DimensionStyle.Name;
+                if (dimensionStyle.DimensionStyle != null) base.SelectedText = dimensionStyle.DimensionStyle.Name;
             }
             toWatch = dimensionStyle as IGeoObject;
         }
@@ -102,8 +102,8 @@ namespace CADability.UserInterface
             {
                 if ((Change as GeoObjectChange).MethodOrPropertyName == "DimensionStyle")
                 {
-                    if ((toWatch as IDimensionStyle).DimensionStyle != null) base.selectedText = (toWatch as IDimensionStyle).DimensionStyle.Name;
-                    else base.selectedText = null;
+                    if ((toWatch as IDimensionStyle).DimensionStyle != null) base.SelectedText = (toWatch as IDimensionStyle).DimensionStyle.Name;
+                    else base.SelectedText = null;
                     propertyPage.Refresh(this);
                 }
             }

--- a/CADability/HatchStyleSelectionProperty.cs
+++ b/CADability/HatchStyleSelectionProperty.cs
@@ -36,8 +36,8 @@ namespace CADability.UserInterface
                 // sollte es den Namen schon geben, werden solange "-" davor und dahintergemacht, bis es den Namen mehr gibt
                 while (hatchStyleList.Find(undef) != null) undef = "-" + undef + "-";
                 choices[0] = undef;
-                if (preselect != null) selectedText = preselect.Name;
-                else selectedText = undef;
+                if (preselect != null) SelectedText = preselect.Name;
+                else SelectedText = undef;
             }
             else
             {
@@ -47,18 +47,18 @@ namespace CADability.UserInterface
                     HatchStyle hst = hatchStyleList[i];
                     choices[i] = hst.Name;
                 }
-                if (preselect != null) selectedText = preselect.Name;
+                if (preselect != null) SelectedText = preselect.Name;
             }
         }
         public void SetSelection(HatchStyle hatchStyle)
         {
             if (hatchStyle == null)
             {
-                base.selectedText = null;
+                base.SelectedText = null;
             }
             else
             {
-                base.selectedText = hatchStyle.Name;
+                base.SelectedText = hatchStyle.Name;
             }
         }
         protected override void OnSelectionChanged(string selected)

--- a/CADability/Layer.cs
+++ b/CADability/Layer.cs
@@ -539,7 +539,7 @@ namespace CADability.Attribute
                 choices[i] = lay.Name;
                 i++;
             }
-            if (select != null) base.selectedText = select.Name;
+            if (select != null) base.SelectedText = select.Name;
         }
 
         public LayerSelectionProperty(ILayer ObjectWithLayer, string resourceId, LayerList ll) :
@@ -565,11 +565,11 @@ namespace CADability.Attribute
                 objectWithLayer = ObjectWithLayer;
                 if (objectWithLayer != null && objectWithLayer.Layer != null)
                 {
-                    selectedText = objectWithLayer.Layer.Name;
+                    SelectedText = objectWithLayer.Layer.Name;
                 }
                 else
                 {
-                    selectedText = undef;
+                    SelectedText = undef;
                 }
             }
             else
@@ -583,7 +583,7 @@ namespace CADability.Attribute
                 }
                 objectWithLayer = ObjectWithLayer;
                 if (objectWithLayer != null && objectWithLayer.Layer != null)
-                    selectedText = objectWithLayer.Layer.Name;
+                    SelectedText = objectWithLayer.Layer.Name;
             }
             toWatch = objectWithLayer as IGeoObject;
         }
@@ -623,8 +623,8 @@ namespace CADability.Attribute
                 if ((Change as GeoObjectChange).MethodOrPropertyName == "Layer" ||
                     (Change as GeoObjectChange).MethodOrPropertyName == "Style")
                 {
-                    if (toWatch.Layer != null) base.selectedText = toWatch.Layer.Name;
-                    else base.selectedText = null;
+                    if (toWatch.Layer != null) base.SelectedText = toWatch.Layer.Name;
+                    else base.SelectedText = null;
                     propertyPage.Refresh(this);
                 }
             }

--- a/CADability/LinePatternSelectionProperty.cs
+++ b/CADability/LinePatternSelectionProperty.cs
@@ -33,11 +33,11 @@ namespace CADability.UserInterface
                 choices[0] = undef;
                 if (select != null)
                 {
-                    base.selectedText = select.Name;
+                    base.SelectedText = select.Name;
                 }
                 else
                 {
-                    base.selectedText = undef;
+                    base.SelectedText = undef;
                 }
             }
             else
@@ -49,7 +49,7 @@ namespace CADability.UserInterface
                 }
                 if (select != null)
                 {
-                    base.selectedText = select.Name;
+                    base.SelectedText = select.Name;
                 }
             }
         }
@@ -71,11 +71,11 @@ namespace CADability.UserInterface
                 choices[0] = undef;
                 if (select != null)
                 {
-                    base.selectedText = select.Name;
+                    base.SelectedText = select.Name;
                 }
                 else
                 {
-                    base.selectedText = undef;
+                    base.SelectedText = undef;
                 }
             }
             else
@@ -87,7 +87,7 @@ namespace CADability.UserInterface
                 }
                 if (select != null)
                 {
-                    base.selectedText = select.Name;
+                    base.SelectedText = select.Name;
                 }
             }
             this.iLinePattern = iLinePattern;
@@ -127,8 +127,8 @@ namespace CADability.UserInterface
                 if ((Change as GeoObjectChange).MethodOrPropertyName == "LinePattern" ||
                     (Change as GeoObjectChange).MethodOrPropertyName == "Style")
                 {
-                    if ((toWatch as ILinePattern).LinePattern != null) base.selectedText = (toWatch as ILinePattern).LinePattern.Name;
-                    else base.selectedText = null;
+                    if ((toWatch as ILinePattern).LinePattern != null) base.SelectedText = (toWatch as ILinePattern).LinePattern.Name;
+                    else base.SelectedText = null;
                     propertyPage.Refresh(this);
                 }
             }

--- a/CADability/LineWidthSelectionProperty.cs
+++ b/CADability/LineWidthSelectionProperty.cs
@@ -32,11 +32,11 @@ namespace CADability.UserInterface
                 choices[0] = undef;
                 if (select != null)
                 {
-                    base.selectedText = select.Name;
+                    base.SelectedText = select.Name;
                 }
                 else
                 {
-                    base.selectedText = undef;
+                    base.SelectedText = undef;
                 }
             }
             else
@@ -48,7 +48,7 @@ namespace CADability.UserInterface
                 }
                 if (select != null)
                 {
-                    base.selectedText = select.Name;
+                    base.SelectedText = select.Name;
                 }
             }
         }
@@ -70,11 +70,11 @@ namespace CADability.UserInterface
                 choices[0] = undef;
                 if (select != null)
                 {
-                    base.selectedText = select.Name;
+                    base.SelectedText = select.Name;
                 }
                 else
                 {
-                    base.selectedText = undef;
+                    base.SelectedText = undef;
                 }
             }
             else
@@ -86,7 +86,7 @@ namespace CADability.UserInterface
                 }
                 if (select != null)
                 {
-                    base.selectedText = select.Name;
+                    base.SelectedText = select.Name;
                 }
             }
             this.iLineWidth = iLineWidth;
@@ -126,8 +126,8 @@ namespace CADability.UserInterface
                 if ((Change as GeoObjectChange).MethodOrPropertyName == "LineWidth" ||
                     (Change as GeoObjectChange).MethodOrPropertyName == "Style")
                 {
-                    if ((toWatch as ILineWidth).LineWidth != null) base.selectedText = (toWatch as ILineWidth).LineWidth.Name;
-                    else base.selectedText = null;
+                    if ((toWatch as ILineWidth).LineWidth != null) base.SelectedText = (toWatch as ILineWidth).LineWidth.Name;
+                    else base.SelectedText = null;
                     propertyPage.Refresh(this);
                 }
             }

--- a/CADability/MultipleChoiceProperty.cs
+++ b/CADability/MultipleChoiceProperty.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.ComponentModel;
-using System.Drawing;
-
-using Wintellect.PowerCollections;
 
 namespace CADability.UserInterface
 {
@@ -25,7 +21,6 @@ namespace CADability.UserInterface
         internal string[] choices; // die Auswahlmöglichkeiten
         //protected int[] imageIndices; // die Indizes in der ImageList, selbe Reihenfolge wie choices
         //protected ImageList images; // die ImageList (kann fehlen)
-        protected string selectedText; // der ausgewählte Text
         protected string unselectedText; // der Text, wenn nichts ausgewählt ist (wenn null, dann ganz leer)
         /// <value>
         /// Back reference to any user item. Not used by the MultipleChoiceProperty object itself.
@@ -42,7 +37,7 @@ namespace CADability.UserInterface
         {
             base.resourceId = resourceId;
             choices = Choices;
-            selectedText = InitialSelection;
+            SelectedText = InitialSelection;
         }
         public MultipleChoiceProperty(string resourceId, int InitialSelection)
             : this()
@@ -50,7 +45,7 @@ namespace CADability.UserInterface
             base.resourceId = resourceId;
             choices = StringTable.GetSplittedStrings(resourceId + ".Values");
             if (InitialSelection >= choices.Length) InitialSelection = 0;
-            selectedText = choices[InitialSelection];
+            SelectedText = choices[InitialSelection];
         }
         /// <summary>
         /// Leerer Konstruktor (für die Verwendung von abgeleiteten Klassen).
@@ -88,13 +83,8 @@ namespace CADability.UserInterface
                 //fillPopupList();
             }
         }
-        public string SelectedText
-        {
-            get
-            {
-                return selectedText;
-            }
-        }
+
+        public string SelectedText { get; protected set; }
         public int ChoiceIndex(string choice)
         {
             for (int i = 0; i < choices.Length; ++i)
@@ -114,32 +104,32 @@ namespace CADability.UserInterface
         {
             if (toSelect < 0)
             {
-                selectedText = null;
+                SelectedText = null;
             }
             else
             {
                 try
                 {
-                    selectedText = choices[toSelect];
+                    SelectedText = choices[toSelect];
                 }
                 catch (IndexOutOfRangeException)
                 {
-                    selectedText = null;
+                    SelectedText = null;
                 }
             }
         }
         protected virtual void OnSelectionChanged(string selected)
         {
             if (SelectionChangedEvent != null) SelectionChangedEvent(this, EventArgs.Empty);
-            selectedText = selected;
-            if (ValueChangedEvent != null) ValueChangedEvent(this, selectedText);
+            SelectedText = selected;
+            if (ValueChangedEvent != null) ValueChangedEvent(this, SelectedText);
         }
         public int CurrentIndex
         {
             get
             {
                 for (int i = 0; i < choices.Length; i++)
-                    if (selectedText == choices[i])
+                    if (SelectedText == choices[i])
                         return i;
                 return -1;
             }
@@ -160,7 +150,7 @@ namespace CADability.UserInterface
         {
             get
             {
-                if (selectedText != null) return selectedText;
+                if (SelectedText != null) return SelectedText;
                 if (unselectedText != null) return "[[ColorTxt:128:128:128]]" + unselectedText;
                 return "";
             }
@@ -169,8 +159,8 @@ namespace CADability.UserInterface
         {
             if (selectedIndex >= 0)
             {
-                selectedText = Choices[selectedIndex];
-                OnSelectionChanged(selectedText);
+                SelectedText = Choices[selectedIndex];
+                OnSelectionChanged(SelectedText);
                 // the following is already done by OnSelectionChanged
                 //SelectionChangedEvent?.Invoke(this, EventArgs.Empty);
                 //ValueChangedEvent?.Invoke(this, selectedText);

--- a/CADability/MultipleChoiceSetting.cs
+++ b/CADability/MultipleChoiceSetting.cs
@@ -74,7 +74,7 @@ namespace CADability
 
             base.propertyLabelText = StringTable.GetString(this.resourceId);
             base.choices = StringTable.GetSplittedStrings(resourceId + ".Values");
-            if (selected >= 0 && selected < base.choices.Length) base.selectedText = base.choices[selected];
+            if (selected >= 0 && selected < base.choices.Length) base.SelectedText = base.choices[selected];
         }
         /// <summary>
         /// Implements <see cref="ISerializable.GetObjectData"/>
@@ -101,7 +101,7 @@ namespace CADability
 
             base.propertyLabelText = StringTable.GetString(this.resourceId);
             base.choices = StringTable.GetSplittedStrings(resourceId + ".Values");
-            if (selected >= 0 && selected < base.choices.Length) base.selectedText = base.choices[selected];
+            if (selected >= 0 && selected < base.choices.Length) base.SelectedText = base.choices[selected];
         }
         protected MultipleChoiceSetting() { }
         #endregion

--- a/CADability/Style.cs
+++ b/CADability/Style.cs
@@ -757,7 +757,7 @@ namespace CADability.Attribute
             choices = styleList.Names;
             if (objectWithStyle != null && objectWithStyle.Style != null)
             {
-                base.selectedText = objectWithStyle.Style.Name;
+                base.SelectedText = objectWithStyle.Style.Name;
             }
             toWatch = objectWithStyle as IGeoObject;
             if (toWatch != null && objectWithStyle.Style != null)
@@ -768,7 +768,7 @@ namespace CADability.Attribute
                 }
                 else
                 {
-                    base.selectedText = null;
+                    base.SelectedText = null;
                     base.unselectedText = (toWatch as IStyle).Style.Name;
                 }
             }
@@ -807,13 +807,13 @@ namespace CADability.Attribute
                 {
                     if ((toWatch as IStyle).Style.Check(toWatch))
                     {
-                        base.selectedText = (toWatch as IStyle).Style.Name;
+                        base.SelectedText = (toWatch as IStyle).Style.Name;
                         base.unselectedText = null;
                     }
                     else
                     {
                         base.unselectedText = (toWatch as IStyle).Style.Name;
-                        base.selectedText = null;
+                        base.SelectedText = null;
                     }
                     propertyPage.Refresh(this);
                 }


### PR DESCRIPTION
Fix compiler warning CS3005 Identifier 'MultipleChoiceProperty.SelectedText' differing only in case is not CLS-compliant.

Move SelectedText to protected set property.

#49 