### PR TITLE
Add NotImplementedException() to Project.Add();

### DIFF
--- a/CADability/Project.cs
+++ b/CADability/Project.cs
@@ -2669,6 +2669,7 @@ namespace CADability
         #region IEnumerable
         public void Add(object toAdd)
         {
+            throw new NotImplementedException();
         }
         IEnumerator IEnumerable.GetEnumerator()
         {


### PR DESCRIPTION
Project has an empty Add method that makes it look deceptively like you can add arbitrary CADAbility objects to a project. If this method is intended to be functional at some point, it should throw an exception in the interim to make it clear to users that attempting to use it that it did not do anything.