### PR TITLE
Remove newline character for Text export

### DIFF
--- a/CADability/ExportDxf.cs
+++ b/CADability/ExportDxf.cs
@@ -330,11 +330,12 @@ namespace CADability.DXF
         }
         private netDxf.Entities.Text ExportText(GeoObject.Text text)
         {
+            var textStringValue = text.TextString.Replace("\r\n", " ");
             System.Drawing.FontStyle fs = System.Drawing.FontStyle.Regular;
             if (text.Bold) fs |= System.Drawing.FontStyle.Bold;
             if (text.Italic) fs |= System.Drawing.FontStyle.Italic;
             System.Drawing.Font font = new System.Drawing.Font(text.Font, 1000.0f, fs);
-            netDxf.Entities.Text res = new netDxf.Entities.Text(text.TextString, Vector2.Zero, text.TextSize * 1000 / font.Height, new TextStyle(text.Font, text.Font + ".ttf"));
+            netDxf.Entities.Text res = new netDxf.Entities.Text(textStringValue, Vector2.Zero, text.TextSize * 1000 / font.Height, new TextStyle(text.Font, text.Font + ".ttf"));
             ModOp toText = ModOp.Fit(GeoPoint.Origin, new GeoVector[] { GeoVector.XAxis, GeoVector.YAxis, GeoVector.ZAxis }, text.Location, new GeoVector[] { text.LineDirection.Normalized, text.GlyphDirection.Normalized, text.LineDirection.Normalized ^ text.GlyphDirection.Normalized });
             res.TransformBy(Matrix4(toText)); // easier than setting normal and rotation
             return res;


### PR DESCRIPTION
Quick band-aid for #238. Current DXF export is preserving newline characters, producing invalid DXF files.