### PR TITLE
Fix compile errors in solutions w/ ManagePackageVersionsCentrally enabled

### DIFF
--- a/CADability/CADability.csproj
+++ b/CADability/CADability.csproj
@@ -8,6 +8,7 @@
     <AssemblyOriginatorKeyFile>CADabilityKey.snk</AssemblyOriginatorKeyFile>
     <AssemblyName>CADability</AssemblyName>
     <Platforms>AnyCPU;x64</Platforms>
+    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Debug'">


### PR DESCRIPTION
When a .sln is using central package version management (by `Directory.Packages.props` etc) and enforces it, a compile error occurs in CADability.csproj, blaming it to use its own versions.

This is fixing it.